### PR TITLE
HTTPS support and use the latest Lens

### DIFF
--- a/doc.html
+++ b/doc.html
@@ -2,9 +2,9 @@
 <html xmlns:mml="http://www.w3.org/1998/Math/MathML">
   <head>
     <title>eLife Lens</title>
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,400italic,600italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,400italic,600italic' rel='stylesheet' type='text/css'>
     
-    <link rel="stylesheet" type="text/css" media="all" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" />
 
     <!-- A combined lens.css will be generated in the bundling process -->
     <!-- While in development, separate links for each CSS file are added, so we don't need a source map -->
@@ -20,7 +20,7 @@
         styles: {".MathJax_Display": {padding: "0em 0em 0em 3em" },".MathJax_SVG_Display": {padding: "0em 0em 0em 3em" }}
       });
     </script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
     <script src='lens.js'></script>
     
@@ -54,7 +54,7 @@
       // This document gets loaded by default
       // --------
       
-      var documentURL = "https://s3.amazonaws.com/elife-cdn/elife-articles/00778/elife00778.xml";
+      var documentURL = "https://s3.amazonaws.com/elife-publishing-cdn/00778/elife-00778-v1.xml";
       
       $(function() {
       

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "gulp-rename": "^1.2.2",
     "through2": "^2.0.0"
   },
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "underscore": "1.8.x",
     "express": "3.3.x",
     "ejs": "*",
-    "lens": "elifesciences/lens.git#2574f0036c548fd7f71e436b6a74f8be9c4e4c33"
+    "lens": "elifesciences/lens.git#b2495985e67c0bc4559bdf281268ef7c09f78be4"
   },
   "devDependencies": {
     "browserify": "*",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "gulp-rename": "^1.2.2",
     "through2": "^2.0.0"
   },
-  "version": "2.1.0"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
- doc.html changed to reflect HTTPS support and point to the most recent eLife sample XML file
- in package.json, bundle with the most recent Lens develop branch version

This combination was tested in the eLife dev environment, and is deemed worthy to release into prod eLife Lens.
