### PR TITLE
Latest lens develop branch, underscore upgraded.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4010,17 +4010,10 @@
       }
     },
     "lens": {
-      "version": "github:elifesciences/lens#1d7d0036fa961de2ff0549334e8412374ffef313",
+      "version": "github:elifesciences/lens#beec4c5e66f4cf8143de344c9d2c2ce1be44a71d",
       "from": "github:elifesciences/lens#develop",
       "requires": {
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
+        "underscore": "1.12.1"
       }
     },
     "liftoff": {


### PR DESCRIPTION
The version of `underscore` was bumped in PR https://github.com/elifesciences/lens/pull/225. 

Here, by updating lens from the current develop branch, it results in removing the old dependency `"underscore": "1.8.3"`, now it uses `"underscore": "1.12.1"`.

This can be repeated on the https://github.com/elifesciences/lens-starter project if it looks good.