### PR TITLE
Fix for gulp-sass version 5 to run bundling.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 'use strict';
  
 const gulp = require('gulp');
-const sass = require('gulp-sass');
+const sass = require('gulp-sass')(require('node-sass'));
 const browserify = require('browserify');
 const uglify = require('gulp-uglify');
 const rename = require('gulp-rename');


### PR DESCRIPTION
Follow-up to PR https://github.com/elifesciences/lens-elife/pull/25

I was unable to run `npm run bundle`, part of the error message:

```
[19:11:26] Starting 'css'...
Error in plugin "gulp-sass"
Message:
    
gulp-sass 5 does not have a default Sass compiler; please set one yourself.
Both the `sass` and `node-sass` packages are permitted.
For example, in your gulpfile:

  var sass = require('gulp-sass')(require('sass'));
```

It looks like using `node-sass` as the sass compiler solves the error and the dependency is already available.

FYI for @NuclearRedeye, just so you're aware of this change.